### PR TITLE
fix: unit size in mm were not converted correctly to px

### DIFF
--- a/client/src/components/LayoutSettings/ExportActions.tsx
+++ b/client/src/components/LayoutSettings/ExportActions.tsx
@@ -1,0 +1,85 @@
+import { buildDecklist, downloadDecklist } from "@/helpers/DecklistHelper";
+import { ExportImagesZip } from "@/helpers/ExportImagesZip";
+import { exportProxyPagesToPdf } from "@/helpers/ExportProxyPageToPdf";
+import { useCardsStore } from "@/store/cards";
+import { useLoadingStore } from "@/store/loading";
+import { useSettingsStore } from "@/store/settings";
+import { Button } from "flowbite-react";
+
+export function ExportActions() {
+  const setLoadingTask = useLoadingStore((state) => state.setLoadingTask);
+  const cards = useCardsStore((state) => state.cards);
+  const originalSelectedImages = useCardsStore(
+    (state) => state.originalSelectedImages
+  );
+  const pageOrientation = useSettingsStore((state) => state.pageOrientation);
+  const pageSizePreset = useSettingsStore((state) => state.pageSizePreset);
+  const pageSizeUnit = useSettingsStore((state) => state.pageSizeUnit);
+  const pageWidth = useSettingsStore((state) => state.pageWidth);
+  const pageHeight = useSettingsStore((state) => state.pageHeight);
+  const columns = useSettingsStore((state) => state.columns);
+  const rows = useSettingsStore((state) => state.rows);
+  const bleedEdgeWidth = useSettingsStore((state) => state.bleedEdgeWidth);
+  const bleedEdge = useSettingsStore((state) => state.bleedEdge);
+  const guideColor = useSettingsStore((state) => state.guideColor);
+  const guideWidth = useSettingsStore((state) => state.guideWidth);
+
+  const handleCopyDecklist = async () => {
+    const text = buildDecklist(cards, { style: "withSetNum", sort: "alpha" });
+    await navigator.clipboard.writeText(text);
+  };
+
+  const handleDownloadDecklist = () => {
+    const text = buildDecklist(cards, { style: "withSetNum", sort: "alpha" });
+    const date = new Date().toISOString().slice(0, 10);
+    downloadDecklist(`decklist_${date}.txt`, text);
+  };
+
+  const handleExport = async () => {
+    setLoadingTask("Generating PDF");
+    await exportProxyPagesToPdf({
+      cards,
+      originalSelectedImages,
+      bleedEdge,
+      bleedEdgeWidthMm: bleedEdgeWidth,
+      guideColor,
+      guideWidthPx: guideWidth,
+      pageOrientation,
+      pageSizePreset,
+      pageSizeUnit,
+      pageWidth,
+      pageHeight,
+      columns,
+      rows,
+    });
+
+    setLoadingTask(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button color="green" onClick={handleExport} disabled={!cards.length}>
+        Export to PDF
+      </Button>
+      <Button
+        color="indigo"
+        onClick={() =>
+          ExportImagesZip({
+            cards,
+            originalSelectedImages,
+            fileBaseName: "card_images",
+          })
+        }
+        disabled={!cards.length}
+      >
+        Export Card Images (.zip)
+      </Button>
+      <Button color="cyan" onClick={handleCopyDecklist}>
+        Copy Decklist
+      </Button>
+      <Button color="blue" onClick={handleDownloadDecklist}>
+        Download Decklist (.txt)
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/LayoutSettings/PageSizeControl.tsx
+++ b/client/src/components/LayoutSettings/PageSizeControl.tsx
@@ -53,7 +53,7 @@ export function PageSizeControl() {
         }}
       >
         {layoutPresets.map((preset) => (
-          <option value={preset.name}>
+          <option key={preset.name} value={preset.name}>
             {getPresetLabel(preset, pageOrientation)}
           </option>
         ))}

--- a/client/src/components/PageSettingsControls.tsx
+++ b/client/src/components/PageSettingsControls.tsx
@@ -1,23 +1,16 @@
-import { buildDecklist, downloadDecklist } from "@/helpers/DecklistHelper";
-import { ExportImagesZip } from "@/helpers/ExportImagesZip";
-import { exportProxyPagesToPdf } from "@/helpers/ExportProxyPageToPdf";
 import { useImageProcessing } from "@/hooks/useImageProcessing";
-import { useCardsStore, useLoadingStore, useSettingsStore } from "@/store";
+import { useCardsStore, useSettingsStore } from "@/store";
 import { Button, Checkbox, HR, Label, TextInput } from "flowbite-react";
 import { ZoomIn, ZoomOut } from "lucide-react";
 import Donate from "./Donate";
+import { ExportActions } from "./LayoutSettings/ExportActions";
 import { PageSizeControl } from "./LayoutSettings/PageSizeControl";
 
 const unit = "mm";
 
 export function PageSettingsControls() {
-  const setLoadingTask = useLoadingStore((state) => state.setLoadingTask);
   const cards = useCardsStore((state) => state.cards);
-  const originalSelectedImages = useCardsStore(
-    (state) => state.originalSelectedImages
-  );
-  const pageWidthIn = useSettingsStore((state) => state.pageWidth);
-  const pageHeightIn = useSettingsStore((state) => state.pageHeight);
+
   const columns = useSettingsStore((state) => state.columns);
   const rows = useSettingsStore((state) => state.rows);
   const bleedEdgeWidth = useSettingsStore((state) => state.bleedEdgeWidth);
@@ -41,35 +34,6 @@ export function PageSettingsControls() {
     unit, // "mm" | "in"
     bleedEdgeWidth, // number
   });
-
-  const handleCopyDecklist = async () => {
-    const text = buildDecklist(cards, { style: "withSetNum", sort: "alpha" });
-    await navigator.clipboard.writeText(text);
-  };
-
-  const handleDownloadDecklist = () => {
-    const text = buildDecklist(cards, { style: "withSetNum", sort: "alpha" });
-    const date = new Date().toISOString().slice(0, 10);
-    downloadDecklist(`decklist_${date}.txt`, text);
-  };
-
-  const handleExport = async () => {
-    setLoadingTask("Generating PDF");
-    await exportProxyPagesToPdf({
-      cards,
-      originalSelectedImages,
-      bleedEdge,
-      bleedEdgeWidthMm: bleedEdgeWidth,
-      guideColor,
-      guideWidthPx: guideWidth,
-      pageWidthInches: pageWidthIn,
-      pageHeightInches: pageHeightIn,
-      columns,
-      rows,
-    });
-
-    setLoadingTask(null);
-  };
 
   return (
     <div className="w-1/4 min-w-[18rem] max-w-[26rem] p-4 bg-gray-100 dark:bg-gray-700 h-full flex flex-col gap-4 overflow-y-auto">
@@ -191,29 +155,7 @@ export function PageSettingsControls() {
 
         <HR className="dark:bg-gray-500" />
 
-        <div className="flex flex-col gap-2">
-          <Button color="green" onClick={handleExport}>
-            Export to PDF
-          </Button>
-          <Button
-            color="indigo"
-            onClick={() =>
-              ExportImagesZip({
-                cards,
-                originalSelectedImages,
-                fileBaseName: "card_images",
-              })
-            }
-          >
-            Export Card Images (.zip)
-          </Button>
-          <Button color="cyan" onClick={handleCopyDecklist}>
-            Copy Decklist
-          </Button>
-          <Button color="blue" onClick={handleDownloadDecklist}>
-            Download Decklist (.txt)
-          </Button>
-        </div>
+        <ExportActions />
       </div>
 
       <div className="w-full flex justify-center">

--- a/client/src/helpers/ImageHelper.ts
+++ b/client/src/helpers/ImageHelper.ts
@@ -229,7 +229,7 @@ export async function addBleedEdge(
       const temp = document.createElement("canvas");
       temp.width = targetCardWidth;
       temp.height = targetCardHeight;
-      const tempCtx = temp.getContext("2d")!;
+      const tempCtx = temp.getContext("2d", { willReadFrequently: true })!;
       tempCtx.drawImage(img, -offsetX, -offsetY, drawWidth, drawHeight);
 
       const cornerSize = 30; // how big the corner fix area is


### PR DESCRIPTION
@kclipsto I noticed the issue with PDF export on ISO formats and prepared a fix! The problem was that units weren’t being converted correctly into pixels, everything was assumed to be in inches!

I also moved the export actions into a dedicated component and fixed a few minor warnings, like missing `key` props on `options` and the `willReadFrequently` flag on canvases 👌🏻