### PR TITLE
Simplify Alternative Artwork Selection and Fix Bleed

### DIFF
--- a/client/src/components/ArtworkModal.tsx
+++ b/client/src/components/ArtworkModal.tsx
@@ -42,6 +42,10 @@ export function ArtworkModal() {
   const appendOriginalSelectedImages = useCardsStore(
     (state) => state.appendOriginalSelectedImages
   );
+  const clearSelectedImage = useCardsStore((state) => state.clearSelectedImage);
+  const clearManySelectedImages = useCardsStore(
+    (state) => state.clearManySelectedImages
+  );
 
   async function getMoreCards() {
     if (!modalCard) return;
@@ -88,8 +92,6 @@ export function ArtworkModal() {
               if (!newCard.imageUrls?.length) return;
 
               const newUuid = crypto.randomUUID();
-              const proxiedUrl = getLocalBleedImageUrl(newCard.imageUrls[0]);
-              const processed = await addBleedEdge(proxiedUrl);
 
               updateCard(modalIndex, {
                 uuid: newUuid,
@@ -105,9 +107,6 @@ export function ArtworkModal() {
                 isUserUpload: false,
               });
 
-              appendSelectedImages({
-                [newUuid]: processed,
-              });
               appendOriginalSelectedImages({
                 [newUuid]: newCard.imageUrls[0],
               });
@@ -145,35 +144,29 @@ export function ArtworkModal() {
                         : "border-transparent"
                     }`}
                     onClick={async () => {
-                      const proxiedUrl = getLocalBleedImageUrl(pngUrl);
-                      const processed = await addBleedEdge(proxiedUrl);
-
                       if (applyToAll) {
-                        const newSelectedImages: Record<string, string> = {};
                         const newOriginalSelectedImages: Record<
                           string,
                           string
                         > = {};
+                        const uuidsToClear: string[] = [];
 
                         cards.forEach((card) => {
                           if (card.name === modalCard.name) {
-                            newSelectedImages[card.uuid] = processed;
                             newOriginalSelectedImages[card.uuid] = pngUrl;
+                            uuidsToClear.push(card.uuid);
                           }
                         });
 
-                        appendSelectedImages(newSelectedImages);
-appendOriginalSelectedImages(
+                        appendOriginalSelectedImages(
                           newOriginalSelectedImages
                         );
+                        clearManySelectedImages(uuidsToClear);
                       } else {
-                        appendSelectedImages({
-                          [modalCard.uuid]: processed,
-                        });
-
                         appendOriginalSelectedImages({
                           [modalCard.uuid]: pngUrl,
                         });
+                        clearSelectedImage(modalCard.uuid);
                       }
 
                       closeArtworkModal();

--- a/client/src/store/cards.ts
+++ b/client/src/store/cards.ts
@@ -17,6 +17,8 @@ type Store = {
   selectedImages: Record<string, string>;
   setSelectedImages: (images: Record<string, string>) => void;
   appendSelectedImages: (newImages: Record<string, string>) => void;
+  clearSelectedImage: (uuid: string) => void;
+  clearManySelectedImages: (uuids: string[]) => void;
 
   originalSelectedImages: Record<string, string>;
   setOriginalSelectedImages: (images: Record<string, string>) => void;
@@ -64,6 +66,20 @@ export const useCardsStore = create<Store>()(
         set((state) => ({
           selectedImages: { ...state.selectedImages, ...newImages },
         })),
+      clearSelectedImage: (uuid) =>
+        set((state) => {
+          const newSelected = { ...state.selectedImages };
+          delete newSelected[uuid];
+          return { selectedImages: newSelected };
+        }),
+      clearManySelectedImages: (uuids) =>
+        set((state) => {
+          const newSelected = { ...state.selectedImages };
+          for (const uuid of uuids) {
+            delete newSelected[uuid];
+          }
+          return { selectedImages: newSelected };
+        }),
 
       originalSelectedImages: {},
       setOriginalSelectedImages: (images) =>


### PR DESCRIPTION
Hey @kclipsto, you have an excellent application. I noticed an issue when selecting alternative artwork for cards. Specifically, when an alternate artwork is selected, the bleed is not applied to the card without manually fiddling with the bleed value in the UI. I believe this was due to the ArtworkModal manually processing the image and bypassing the useImageProcessing hook in PageView. 

I also included a quality of life feature that allows for assigning the same image to all instances of a specific card via a checkbox on the ArtworkModal. 

This PR contains the following:

* Fixes bleed not being applied to alternative artwork.
* Adds the ability to change all instances of the same card.

